### PR TITLE
chore(deps): move vue, vuetify to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
     "styleguide": "vue-styleguidist server",
     "styleguide:build": "vue-styleguidist build"
   },
-  "dependencies": {
-    "dayspan": "^0.12.2",
-    "material-design-icons-iconfont": "^3.0.3",
+  "peerDependencies": {
     "vue": "^2.3.3",
     "vuetify": "^1.3.9"
+  },
+  "dependencies": {
+    "dayspan": "^0.12.2"
   },
   "devDependencies": {
     "autoprefixer": "^7.1.2",
@@ -47,6 +48,8 @@
     "friendly-errors-webpack-plugin": "^1.1.3",
     "html-webpack-plugin": "^2.28.0",
     "http-proxy-middleware": "^0.17.3",
+    "material-design-icons-iconfont": "^3.0.3",
+    "moment": "2.7.0",
     "node-sass": "^4.5.2",
     "npm-run-all": "^4.0.2",
     "opn": "^5.1.0",
@@ -57,15 +60,16 @@
     "semver": "^5.3.0",
     "shelljs": "^0.7.6",
     "url-loader": "^0.5.8",
+    "vue": "^2.6.10",
     "vue-loader": "^12.1.0",
     "vue-style-loader": "^3.0.1",
-    "vue-template-compiler": "^2.3.3",
+    "vue-template-compiler": "^2.6.10",
+    "vuetify": "^1.5.16",
     "webpack": "^2.6.1",
     "webpack-bundle-analyzer": "^2.2.1",
     "webpack-dev-middleware": "^1.10.0",
     "webpack-hot-middleware": "^2.18.0",
-    "webpack-merge": "^4.1.0",
-    "moment": "2.7.0"
+    "webpack-merge": "^4.1.0"
   },
   "engines": {
     "node": ">= 4.0.0",


### PR DESCRIPTION
I removed vue and vuetify from dependencies as they are installed by any users of your package. I also moved the material icon as a devDependency since it was only used to build docs.
I tested by rebuilding the package-lock.json but I imagine you will want to rebuild it yourself locally using `npm i`